### PR TITLE
Allow running the role on a remote host

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,7 +63,7 @@
     host: "https://{{ openshift_api_vip }}:6443"
     kubeconfig: "{{ kubeconfig }}"
     state: present
-    resource_definition: "{{ lookup('template', role_path + '/files/gpu-operator.yaml.j2') }}"
+    resource_definition: "{{ lookup('template', role_path + '/templates/gpu-operator.yaml.j2') }}"
     validate_certs: false
 
 - name: Set NGC pull secret auth
@@ -78,7 +78,7 @@
     host: "https://{{ openshift_api_vip }}:6443"
     kubeconfig: "{{ kubeconfig }}"
     state: present
-    resource_definition: "{{ lookup('template', role_path + '/files/ngc-secret.yaml.j2') }}"
+    resource_definition: "{{ lookup('template', role_path + '/templates/ngc-secret.yaml.j2') }}"
     validate_certs: false
   when: gpu_type == "vgpu"
 
@@ -87,7 +87,7 @@
     host: "https://{{ openshift_api_vip }}:6443"
     kubeconfig: "{{ kubeconfig }}"
     state: present
-    resource_definition: "{{ lookup('template', role_path + '/files/licensing-config.yaml.j2') }}"
+    resource_definition: "{{ lookup('template', role_path + '/templates/licensing-config.yaml.j2') }}"
     validate_certs: false
   when: gpu_type == "vgpu"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
     host: "https://{{ openshift_api_vip }}:6443"
     kubeconfig: "{{ kubeconfig }}"
     state: present
-    src: nfd-operator.yaml
+    resource_definition: "{{ lookup('file', role_path + '/files/nfd-operator.yaml') }}"
     validate_certs: false
 
 - name: Wait for NFD operator to start
@@ -39,7 +39,7 @@
     host: "https://{{ openshift_api_vip }}:6443"
     kubeconfig: "{{ kubeconfig }}"
     state: present
-    src: nfd-instance.yaml
+    resource_definition: "{{ lookup('file', role_path + '/files/nfd-instance.yaml') }}"
     validate_certs: false
 
 - name: Wait for NFD instance to become available
@@ -63,8 +63,7 @@
     host: "https://{{ openshift_api_vip }}:6443"
     kubeconfig: "{{ kubeconfig }}"
     state: present
-    template:
-      - gpu-operator.yaml.j2
+    resource_definition: "{{ lookup('template', role_path + '/files/gpu-operator.yaml.j2') }}"
     validate_certs: false
 
 - name: Set NGC pull secret auth
@@ -74,14 +73,21 @@
     ngc_credentials: "$oauthtoken:{{ ngc_api_key }}"
   when: gpu_type == "vgpu"
 
-- name: Create vGPU config resources
+- name: Create NGC secret resource
   kubernetes.core.k8s:
     host: "https://{{ openshift_api_vip }}:6443"
     kubeconfig: "{{ kubeconfig }}"
     state: present
-    template:
-      - ngc-secret.yaml.j2
-      - licensing-config.yaml.j2
+    resource_definition: "{{ lookup('template', role_path + '/files/ngc-secret.yaml.j2') }}"
+    validate_certs: false
+  when: gpu_type == "vgpu"
+
+- name: Create licensing config resource
+  kubernetes.core.k8s:
+    host: "https://{{ openshift_api_vip }}:6443"
+    kubeconfig: "{{ kubeconfig }}"
+    state: present
+    resource_definition: "{{ lookup('template', role_path + '/files/licensing-config.yaml.j2') }}"
     validate_certs: false
   when: gpu_type == "vgpu"
 
@@ -107,7 +113,7 @@
     host: "https://{{ openshift_api_vip }}:6443"
     kubeconfig: "{{ kubeconfig }}"
     state: present
-    src: "gpu-cluster-policy-{{ gpu_type }}.yaml"
+    resource_definition: "{{ lookup('file', role_path + '/files/gpu-cluster-policy-' + gpu_type + '.yaml') }}"
     validate_certs: false
 
 - name: Wait for at least one node to have (v)GPU


### PR DESCRIPTION
Using the content of a resource definition file rather than its path allows the role to run on a remote host, e.g. via `delegate_to`. 
In this case the content will be read from a file on the control host and sent over to the delegated node. We still want to keep Kubernetes resource definition as separate file instead of embedding them into the role's tasks.